### PR TITLE
fix: header expands vertically when menu drops

### DIFF
--- a/assets/css/templatemo-seo-dream.css
+++ b/assets/css/templatemo-seo-dream.css
@@ -108,7 +108,6 @@ html, body {
   -ms-text-size-adjust: 100%;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -moz-transform: scale(.9);
 }
 
 
@@ -261,7 +260,6 @@ header
 
 .background-header {
   background-color: #071669!important;
-  height: 80px!important;
   position: fixed!important;
   top: 0px;
   left: 0px;
@@ -304,7 +302,6 @@ header
   left: 0px;
   right: 0px;
   z-index: 100;
-  height: 100px;
   -webkit-transition: all .5s ease 0s;
   -moz-transition: all .5s ease 0s;
   -o-transition: all .5s ease 0s;
@@ -361,6 +358,7 @@ header
   -o-transition: all 0.3s ease 0s;
   transition: all 0.3s ease 0s;
   position: relative;
+  padding-bottom: 15px;
   z-index: 999;
 }
 


### PR DESCRIPTION
- remove moz-scaling (makes it look odd in firefox)
- remove fixed height of header and background-header, allows div to naturally expand when menu drops
- add padding to menu so it doesn't sit on the bottom of the div when it drops

did this all in firefox so you may want to double-check in chrome

ignore the blank space around the site in the screenshots below, I was using firefox's style editor to scale the website down to the size where the problem happens

before (with moz-scaling removed bc that was causing everything to shrink in strange ways in firefox only)
![Screenshot from 2021-09-11 13-33-42](https://user-images.githubusercontent.com/1034912/132959509-e8d9fc32-2ee3-418e-b69e-3b193d751ad5.png)

after
![Screenshot from 2021-09-11 13-32-50](https://user-images.githubusercontent.com/1034912/132959512-4a9735a7-4e33-4d3e-9082-fea26c15d56a.png)
